### PR TITLE
Release v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ modified slightly from the default theme.
 Download the latest release:
 
 ```
-curl -sL https://github.com/statusok/genblog/releases/download/v0.1.0/blog.tar.gz | tar xvz
+curl -sL https://github.com/statusok/genblog/releases/download/v0.1.1/blog.tar.gz | tar xvz
 cd blog
 ```
 


### PR DESCRIPTION
Change name of directory of uncompressed tarball.
It is now `blog` for aesthetics.

https://github.com/statusok/genblog/releases/tag/v0.1.1