### PR TITLE
Generate redirects from config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
-name: Build
+name: genblog
 on: [push]
 jobs:
 
   build:
-    name: Build
+    name: build
     runs-on: macOS-latest
     steps:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ modified slightly from the default theme.
 Download the latest release:
 
 ```
-curl -sL https://github.com/statusok/genblog/releases/download/v0.1.1/blog.tar.gz | tar xvz
+curl -sL https://github.com/statusok/genblog/releases/download/v0.2.0/blog.tar.gz | tar xvz
 cd blog
 ```
 
@@ -122,8 +122,7 @@ client = Example::Client.new(
 The magic comments demarcate code blocks by id.
 In this example, the id is `instantiate`.
 
-This allows you to run the embedded code,
-or tests against the embedded code,
+This allows you to run, lint, and test embedded code
 separate from Markdown prose.
 
 ## Configure


### PR DESCRIPTION
Redirects are configured like this:

```
{
  "blog": {
    "name": "Blog",
    "url": "https://blog.example.com"
  },
  "articles": [
    {
      "id": "article-with-redirects",
      "published": "2018-02-01",
      "redirects": [
        "/article-original-name",
        "/article-renamed-again",
        "/this-feature-works-only-on-netlify",
      ]
    }
  ]
}
```

The local server now respects these redirects with 302 status code.

The build generates a Netlify `_redirects` file.
https://docs.netlify.com/routing/redirects/